### PR TITLE
Support newer endpoint URLs that are missing the API endpoint

### DIFF
--- a/automatic-alternative-text.php
+++ b/automatic-alternative-text.php
@@ -258,6 +258,13 @@ function aat_get_caption( $attachment_id ) {
 		return false;
 	}
 
+	/* Support newer endpoint URLs that are missing the API endpoint. */
+	$has_endpoint = strpos( $endpoint, 'vision/v1.0' );
+
+	if ( $has_endpoint === false ) {
+		$endpoint = trailingslashit( $endpoint ) . 'vision/v1.0';
+	}
+
 	/* Escape and add describe endpoint. */
 	$url = esc_url( trailingslashit( $endpoint ) . 'describe' );
 

--- a/automatic-alternative-text.php
+++ b/automatic-alternative-text.php
@@ -266,7 +266,7 @@ function aat_get_caption( $attachment_id ) {
 	}
 
 	/* Escape and add describe endpoint. */
-	$url = esc_url( trailingslashit( $endpoint ) . 'describe' );
+	$url = esc_url_raw( trailingslashit( $endpoint ) . 'describe' );
 
 	/* Make API request. */
 	$response = wp_remote_post( $url, array(

--- a/readme.txt
+++ b/readme.txt
@@ -46,6 +46,9 @@ Not yet. I might add this functionality in a future version.
 
 == Changelog ==
 
+= 1.1.3 =
+* Support newer endpoint URLs that are missing the API endpoint, since Azure does not include this in the resource overview anymore.
+
 = 1.1.2 =
 * Fix admin notice appearing even when dismissed.
 


### PR DESCRIPTION
Support newer endpoint URLs that are missing the API endpoint, since Azure does not include this in the resource overview anymore. Fixes #6.